### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/cloudformation-samples/WinAssociationDomainJoinAutomation.yaml
+++ b/cloudformation-samples/WinAssociationDomainJoinAutomation.yaml
@@ -123,7 +123,7 @@ Resources:
           };
       Handler: index.handler
       Role: !GetAtt LambdaSSMRole.Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 10
   WriteDomainJoinScript:
     Type: Custom::WriteScript

--- a/systems-manager-samples/windowsdeployjoindomain.yaml
+++ b/systems-manager-samples/windowsdeployjoindomain.yaml
@@ -168,7 +168,7 @@ mainSteps:
                   };
               Handler: index.handler
               Role: !GetAtt LambdaSSMRole.Arn
-              Runtime: nodejs10.x
+              Runtime: nodejs14.x
               Timeout: 10
           WriteDomainJoinMOF:
             Type: Custom::WriteMOFFile


### PR DESCRIPTION
CloudFormation templates in aws-systems-manager-cloudformation-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.