### PR TITLE
Add example of using Chef with State Manager

### DIFF
--- a/cloudformation-samples/ChefAssociation.yaml
+++ b/cloudformation-samples/ChefAssociation.yaml
@@ -1,0 +1,109 @@
+Description: "Deploy Single EC2 Linux Instance"
+Parameters:
+  # Using SSM Parameter Store to fetch the Latest AMI for Amazon Linux, eliminates the need for AMI Mappings
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+  GitHubOwner:
+    Type: 'String'
+  GitHubRepo:
+    Type: 'String'
+  GitHubBranch:
+    Type: 'String'
+Resources:
+  SSMAssocLogs:
+    Type: AWS::S3::Bucket
+  SSMInstanceRole: 
+    Type : AWS::IAM::Role
+    Properties:
+      Policies:
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - s3:GetObject
+                Resource: 
+                  - !Sub 'arn:aws:s3:::aws-ssm-${AWS::Region}/*'
+                  - !Sub 'arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*'
+                  - !Sub 'arn:aws:s3:::amazon-ssm-${AWS::Region}/*'
+                  - !Sub 'arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*'
+                  - !Sub 'arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*'
+                  - !Sub 'arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*'
+                Effect: Allow
+          PolicyName: ssm-custom-s3-policy
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                  - s3:ListBucket
+                Resource: 
+                  - !Sub 'arn:${AWS::Partition}:s3:::${SSMAssocLogs}/*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${SSMAssocLogs}'
+                Effect: Allow
+          PolicyName: s3-instance-bucket-policy
+      Path: /
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+            - "ssm.amazonaws.com"
+          Action: "sts:AssumeRole"
+  SSMInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Roles:
+      - !Ref SSMInstanceRole
+  EC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: !Ref LatestAmiId
+      InstanceType: "t3.small"
+      IamInstanceProfile: !Ref SSMInstanceProfile
+  ChefAssociation:
+    Type: AWS::SSM::Association
+    Properties:
+      Name: AWS-ApplyChefRecipes
+      WaitForSuccessTimeoutSeconds: 300
+      # Targeting Instance by InstanceId passed from the Logical ID of Instance being created 
+      # in CloudFormation
+      Targets:
+        - Key: InstanceIds
+          Values: [ !Ref EC2Instance ]
+      OutputLocation:
+        S3Location: 
+          OutputS3BucketName: !Ref SSMAssocLogs
+          OutputS3KeyPrefix: 'logs/'
+      Parameters:
+        SourceType:
+        # Getting an Ansible Playbook from a GitHub Location
+        SourceType:
+          - 'GitHub'
+        # At a minimum must include the following GitHub repo information, if using a private repo 
+        # would want to include the GitHub Token option
+        SourceInfo:
+          -  !Sub |
+              {"owner":"${GitHubOwner}",
+              "repository":"${GitHubRepo}",
+              "path":"",
+              "getOptions":"branch:${GitHubBranch}"}
+        RunList:
+        - '{"recipe[HelloWorld::HelloWorldRecipe]", "recipe[HelloWorld::InstallApp]"}'
+        JsonAttributesContent:
+        - '{"state": "visible","colors": {"foreground": "light-blue","background": "dark-gray"}}'
+        ChefClientVersion:
+        - '14'
+        ChefClientArguments:
+        - "{--fips}"
+        WhyRun: false
+Outputs:
+  WebServerPublic:
+    Value: !GetAtt 'EC2Instance.PublicDnsName'
+    Description: Public DNS for WebServer

--- a/cloudformation-samples/README.md
+++ b/cloudformation-samples/README.md
@@ -12,6 +12,8 @@
 
 **[BashScriptSSMAutomationTags.yaml](BashScriptSSMAutomationTags.yaml)** - This template demonstrates how you can run a bash script with CloudFormation using State Manager and Automation for a more complex workflow with multiple steps. Target is based on Tags.
 
+**[ChefAssociation.yaml](ChefAssociation.yaml)** - This template demonstrates how you can use Chef with CloudFormation and AWS Systems Manager. This CFN Template grabs the Chef Recipe from a Github repo. Target is based on Instance ID. 
+
 **[WinAssociationDomainJoin.yaml](WinAssociationDomainJoin.yaml)** - This template demonstrates how you can join a Windows AD Domain with CloudFormation using State Manager. Target is based on Tags.
 
 **[WinAssociationDomainJoinAutomation.yaml](WinAssociationDomainJoinAutomation.yaml)** - This template demonstrates how you can join a Windows AD Domain with CloudFormation using State Manager and Automation for a more complex workflow with multiple steps. Target is based on Tags.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Added an example CloudFormation template which illustrates how to use Chef with AWS Systems Manager State Manager.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
